### PR TITLE
Users CRUD y admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ pnpm-debug.log*
 
 tmp/
 *.bak
+firebase-credentials.json
+credenciales

--- a/backend/app/api/routes_admin.py
+++ b/backend/app/api/routes_admin.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr
+from firebase_admin import auth
+from core.auth import verify_token, check_admin
+from core.firebase import db
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+class NewUserRequest(BaseModel):
+    email: EmailStr
+    password: str
+    display_name: str | None = None
+    role: str = "user"
+
+@router.post("/create-user")
+def create_user(new_user: NewUserRequest, user=Depends(verify_token)):
+    check_admin(user)
+
+    try:
+        user_record = auth.create_user(
+            email=new_user.email,
+            password=new_user.password,
+            display_name=new_user.display_name,
+        )
+
+        db.collection("users").document(user_record.uid).set({
+            "email": new_user.email,
+            "name": new_user.display_name or "",
+            "role": new_user.role,
+        })
+
+        auth.set_custom_user_claims(user_record.uid, {"role": new_user.role})
+
+        return {"uid": user_record.uid, "email": user_record.email}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/backend/app/api/routes_user.py
+++ b/backend/app/api/routes_user.py
@@ -1,0 +1,27 @@
+from fastapi import APIRouter, Depends, HTTPException
+from models.user import UserMetadata
+from services import user_service
+from core.auth import verify_token
+
+router = APIRouter(prefix="/users", tags=["users"])
+
+@router.get("/")
+def list_users(user=Depends(verify_token)):
+    return user_service.list_users()
+
+@router.get("/me")
+def get_current_user(user=Depends(verify_token)):
+    user_data = user_service.get_user(user["uid"])
+    if not user_data:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user_data
+
+@router.post("/me")
+def create_or_update_current_user(data: UserMetadata, user=Depends(verify_token)):
+    user_service.create_or_update_user(user["uid"], data.dict())
+    return {"status": "ok"}
+
+@router.delete("/me")
+def delete_current_user(user=Depends(verify_token)):
+    user_service.delete_user(user["uid"])
+    return {"status": "deleted"}

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Request, HTTPException, Depends
+from fastapi import Request, HTTPException
 from firebase_admin import auth
 
 async def verify_token(request: Request):
@@ -9,6 +9,10 @@ async def verify_token(request: Request):
     token = auth_header.split(" ")[1]
     try:
         decoded_token = auth.verify_id_token(token)
-        return decoded_token  # contiene uid, email, etc.
+        return decoded_token  # contiene uid, email, claims, etc.
     except Exception:
         raise HTTPException(status_code=401, detail="Invalid token")
+
+def check_admin(user_token):
+    if user_token.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="Admin only access")

--- a/backend/app/core/firebase.py
+++ b/backend/app/core/firebase.py
@@ -1,7 +1,6 @@
 import firebase_admin
 from firebase_admin import credentials, firestore
 
-# Path to the Firebase credentials file in the container
 cred_path = "/app/firebase-credentials.json"
 cred = credentials.Certificate(cred_path)
 firebase_admin.initialize_app(cred)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,9 +2,12 @@ import os
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from api.routes_file import router as files_router
+from api.routes_user import router as users_router
 
 app = FastAPI()
 app.include_router(files_router)
+app.include_router(users_router)
+
 
 def custom_openapi():
     if app.openapi_schema:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,13 +1,13 @@
-import os
 from fastapi import FastAPI
 from fastapi.openapi.utils import get_openapi
 from api.routes_file import router as files_router
 from api.routes_user import router as users_router
+from api.routes_admin import router as admin_router
 
 app = FastAPI()
 app.include_router(files_router)
 app.include_router(users_router)
-
+app.include_router(admin_router)
 
 def custom_openapi():
     if app.openapi_schema:
@@ -38,6 +38,7 @@ def custom_openapi():
 app.openapi = custom_openapi
 
 if __name__ == "__main__":
+    import os
     import uvicorn
     port = int(os.environ.get("PORT", 8000))
     uvicorn.run("main:app", host="0.0.0.0", port=port)

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel, EmailStr
+
+class UserMetadata(BaseModel):
+    name: str
+    email: EmailStr
+    role: str = "user"

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,0 +1,17 @@
+from core.firebase import db
+
+def get_user(uid: str):
+    doc = db.collection("users").document(uid).get()
+    if not doc.exists:
+        return None
+    return doc.to_dict()
+
+def create_or_update_user(uid: str, data: dict):
+    db.collection("users").document(uid).set(data, merge=True)
+
+def delete_user(uid: str):
+    db.collection("users").document(uid).delete()
+
+def list_users():
+    docs = db.collection("users").stream()
+    return [{**doc.to_dict(), "id": doc.id} for doc in docs]

--- a/backend/get_token.py
+++ b/backend/get_token.py
@@ -1,6 +1,6 @@
 import requests
 
-API_KEY = "AIzaSyAkR-ghiPN0oQqnC7wk4pD7GmJwM-LyogI"
+API_KEY = "tu-api-key"
 EMAIL = "tu_email@ejemplo.com"
 PASSWORD = "tu_contraseña"
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,3 +5,4 @@ google-cloud-storage
 python-dotenv
 firebase-admin
 google-cloud-firestore
+pydantic[email]

--- a/create_admin.py
+++ b/create_admin.py
@@ -1,0 +1,24 @@
+import firebase_admin
+from firebase_admin import credentials, auth
+
+cred_path = "./backend/credenciales/clave-gcp.json"
+
+cred = credentials.Certificate(cred_path)
+firebase_admin.initialize_app(cred)
+
+admin_email = "admin@tudominio.com"
+admin_password = "admin1234"
+
+def create_admin():
+    try:
+        user = auth.get_user_by_email(admin_email)
+        print(f"Usuario admin ya existe: {user.uid}")
+    except auth.UserNotFoundError:
+        user = auth.create_user(email=admin_email, password=admin_password)
+        print(f"Usuario admin creado: {user.uid}")
+
+    auth.set_custom_user_claims(user.uid, {"role": "admin"})
+    print(f"Claim 'admin' asignado a usuario {user.uid}")
+
+if __name__ == "__main__":
+    create_admin()


### PR DESCRIPTION
# Resumen
### Este PR agrega las siguientes files:
```
-routes_admin
-routes_user
```
Generan las rutas para los endpoints del user admin y user, teniendo admin un /create-user (siendo el único capaz de crear usuarios) y /list-users y el user teniendo un CRUD, integrándose con el CRUD de documentos ya hecho
```
-user.py
```
Se agrega el modelo user, que tiene un name (string), email (emailStr) y role (user por default)

```
-user.service.py
```
Se agrega el servicio users, donde manejamos el get_users, create_or_update_user (para updatear un usuario o crearlo si no existe, aunque siempre va a existir porque se modifica a si mismo, es un arreglo para el futuro), delete_user (elimina el usuario) y list_users (lista todos los usuarios, aunque solo el admin deberia ser capaz de listarlos)

```
-get_token.py
```
Se agrega el metodo get_token que a partir de usuario y contrase;a validos, se obtiene un token de sesion por el cual podemos probar los endpoints

### Se modifican las siguientes files
```
-auth.py
```
se agrega el método ```check_admin``` donde si el usuario logueado no es un admin, no puede interactuar con las funcionalidades del mismo (esto se prueba en POSTMAN o Swagger con el auth token que puede verse en get_token.py agregando el user y la contrase;a del usuario del cual se quiere probar)


esto se corre con ./deploy.sh desde la carpeta root, pero se puede acceder mediante https://backend-217609179837.us-central1.run.app/docs
